### PR TITLE
Make icons look better in value boxes

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Change Log for faicons
+
+All notable changes to faicons will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [UNRELEASED]
+
+* Icons now look better inside Shiny's `value_box()`. (#8)
+
+## [0.2.1] - 2022-09-30
+
+Initial release

--- a/faicons/_core.py
+++ b/faicons/_core.py
@@ -168,7 +168,6 @@ def icon_svg(
             margin_right=margin_right,
             position=position,
             vertical_align="-0.125em",
-            # font_size="inherit",
             overflow="visible",
         ),
     )

--- a/faicons/_core.py
+++ b/faicons/_core.py
@@ -155,6 +155,7 @@ def icon_svg(
         None if title is None else tags.title(html_escape(title)),
         Tag("path", d=svg["path"]),
         **svg_attrs,
+        class_="fa",
         style=css(
             fill=fill,
             fill_opacity=fill_opacity,
@@ -167,7 +168,7 @@ def icon_svg(
             margin_right=margin_right,
             position=position,
             vertical_align="-0.125em",
-            font_size="inherit",
+            # font_size="inherit",
             overflow="visible",
         ),
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +26,7 @@ project_urls =
     Source Code = https://github.com/rstudio/py-faicons
 
 [options]
-python_requires = >=3.7
+python_requires = >=3.8
 packages = find:
 test_suite = tests
 include_package_data = True


### PR DESCRIPTION
This PR makes `icon_svg()` look much better inside a shiny `value_box()`, for example:

```python
import faicons as fa
from shiny.express import ui

with ui.value_box(showcase=fa.icon_svg("gear")):
    "A value box"
    "With a value"
```

### Before

<img width="539" alt="Screenshot 2023-12-28 at 5 29 55 PM" src="https://github.com/posit-dev/py-faicons/assets/1365941/2cb88249-282a-48a8-91cd-0527f02e51f3">


### After

<img width="550" alt="Screenshot 2023-12-28 at 5 29 35 PM" src="https://github.com/posit-dev/py-faicons/assets/1365941/cd684c12-2d70-4b49-b095-d957f924c402">



It does this by including a `class="fa"` to the `<svg>` markup, which `{bslib}` will recognize as a fontawesome icon, and thus add the gradient and `font-size` style. 